### PR TITLE
refactor/update initial setup

### DIFF
--- a/packages/domains/src/funds/__tests__/approve.test.ts
+++ b/packages/domains/src/funds/__tests__/approve.test.ts
@@ -1,0 +1,98 @@
+import approve from "../approve";
+
+import {
+  buildMock as buildUserMock,
+  buildUser,
+} from "../../user/__tests__/user-factory";
+
+import { FundsStatus } from "../ports/database";
+
+import { buildFund, buildMock as buildFundsMock } from "./funds-factory";
+
+const buildMock = ({ fundsMock, userMock }: any = {}) => {
+  return {
+    Database: buildFundsMock(fundsMock),
+    User: buildUserMock(userMock),
+    Socket: {
+      emit: jest.fn(),
+    },
+  };
+};
+
+describe("approve()", () => {
+  const user = buildUser();
+  const agent = buildUser({
+    id: "agent-id",
+  });
+  const fund = buildFund({
+    userId: user.id,
+  });
+
+  const input = {
+    agentId: agent.id,
+    id: fund.id,
+  };
+
+  it("calls database, update funds status and add user balance", async () => {
+    const { Database, User, Socket } = buildMock({
+      fundsMock: {
+        findById: jest.fn().mockResolvedValue(fund),
+      },
+      userMock: {
+        get: jest
+          .fn()
+          .mockImplementation((id) =>
+            [user, agent].find(({ id: filteredId }) => filteredId === id)
+          ),
+      },
+    });
+
+    await approve(Database, User, Socket, input);
+
+    expect(Database.update).toBeCalledWith({
+      ...input,
+      status: FundsStatus.CREDITED,
+      updatedAt: expect.any(Number),
+    });
+
+    expect(User.addBalance).toBeCalledWith(Socket, {
+      user,
+      value: fund.value,
+    });
+
+    expect(Socket.emit).toBeCalledWith({
+      channel: "server:funds:approve",
+      message: {
+        id: fund.id,
+        userId: fund.userId,
+      },
+    });
+  });
+
+  describe("provides inexistent funds", () => {
+    it("throws an error", async () => {
+      const { Database, User, Socket } = buildMock();
+
+      await expect(approve(Database, User, Socket, input)).rejects.toThrowError(
+        "Fund not found"
+      );
+    });
+  });
+
+  describe("provides credited funds", () => {
+    it("throws an error", async () => {
+      const { Database, User, Socket } = buildMock({
+        fundsMock: {
+          findById: jest.fn().mockResolvedValue({
+            ...fund,
+            status: FundsStatus.CREDITED,
+          }),
+        },
+      });
+
+      await expect(approve(Database, User, Socket, input)).rejects.toThrowError(
+        "Only PENDING funds can be approved"
+      );
+    });
+  });
+});

--- a/packages/domains/src/funds/__tests__/funds-factory.ts
+++ b/packages/domains/src/funds/__tests__/funds-factory.ts
@@ -1,0 +1,26 @@
+import { Funds, FundsStatus } from "../ports/database";
+
+export const buildMock = (fundsFactory?: any) => {
+  const mock = {
+    ...jest.requireMock("../ports/database"),
+  }.default;
+
+  return {
+    ...mock,
+    ...jest.requireMock("../").default,
+    ...fundsFactory,
+  };
+};
+
+export const buildFund = (data?: any): Funds => {
+  return {
+    id: "id",
+    userId: "user-id",
+    agentId: "agent-id",
+    value: 1000,
+    createdAt: new Date().getTime(),
+    updatedAt: new Date().getTime(),
+    status: FundsStatus.PENDING,
+    ...data,
+  };
+};

--- a/packages/domains/src/funds/__tests__/get-pending.test.ts
+++ b/packages/domains/src/funds/__tests__/get-pending.test.ts
@@ -1,0 +1,43 @@
+import getPending from "../get-pending";
+
+import { buildMock as buildUserMock } from "../../user/__tests__/user-factory";
+
+import { FundsStatus } from "../ports/database";
+
+import { buildSkin } from "../../skin/__tests__/skin-factory";
+
+import { buildMock as buildFundsMock } from "./funds-factory";
+
+const buildMock = ({ fundsMock, userMock }: any = {}) => {
+  return {
+    Database: buildFundsMock(fundsMock),
+    User: buildUserMock(userMock),
+  };
+};
+
+describe("getPending()", () => {
+  const skin = buildSkin();
+
+  it("calls database and add username for each fund", async () => {
+    const { Database, User } = buildMock({
+      fundsMock: {
+        findBy: jest.fn().mockResolvedValue([skin]),
+      },
+      userMock: {
+        get: jest.fn().mockResolvedValue({ username: "username" })
+      },
+    });
+
+    await getPending(Database, User, {});
+
+    expect(
+      Database.findBy({
+        status: {
+          $ne: FundsStatus.CREDITED,
+        },
+      })
+    );
+
+    expect(User.get).toBeCalledTimes(1);
+  });
+});

--- a/packages/domains/src/funds/__tests__/request.test.ts
+++ b/packages/domains/src/funds/__tests__/request.test.ts
@@ -1,0 +1,67 @@
+import request from "../request";
+
+import {
+  buildMock as buildUserMock,
+  buildUser,
+} from "../../user/__tests__/user-factory";
+
+import { buildFund, buildMock as buildFundsMock } from "./funds-factory";
+
+const buildMock = ({ fundsMock, userMock }: any = {}) => {
+  return {
+    Database: buildFundsMock(fundsMock),
+    User: buildUserMock(userMock),
+    Socket: {
+      emit: jest.fn(),
+    },
+  };
+};
+
+describe("request()", () => {
+  const user = buildUser();
+  const fund = buildFund();
+  const input = {
+    userId: user.id,
+    value: 100,
+  };
+
+  it("calls database and create fund", async () => {
+    const { Database, User, Socket } = buildMock({
+      userMock: {
+        get: jest.fn().mockResolvedValue(user),
+      },
+      fundsMock: {
+        create: jest.fn().mockResolvedValue(fund),
+      },
+    });
+
+    await request(Database, User, Socket, input);
+
+    expect(Database.create).toBeCalledWith({
+      createdAt: expect.any(Number),
+      updatedAt: expect.any(Number),
+      userId: user.id,
+      value: input.value,
+    });
+
+    expect(Socket.emit).toBeCalledWith({
+      channel: "server:funds:request",
+      message: {
+        id: fund.id,
+      },
+    });
+  });
+
+  describe("provides invalid value", () => {
+    it("throws an error", async () => {
+      const { Database, User, Socket } = buildMock();
+
+      await expect(request(Database, User, Socket, {
+        ...input,
+        value: 0
+      })).rejects.toThrowError(
+        "Funds can only be positive number"
+      );
+    });
+  });
+});

--- a/packages/domains/src/funds/request.ts
+++ b/packages/domains/src/funds/request.ts
@@ -20,6 +20,10 @@ const request = async (
 ) => {
   const user = await User.get(input.userId, "id");
 
+  if(input.value <= 0) {
+    throw new Error("Funds can only be positive number");
+  }
+
   const fund = await Database.create({
     createdAt: DateTime.now().toMillis(),
     updatedAt: DateTime.now().toMillis(),

--- a/packages/domains/src/skin/__tests__/add.test.ts
+++ b/packages/domains/src/skin/__tests__/add.test.ts
@@ -1,17 +1,11 @@
 import {
-  buildMock as buildSkinMock,
-  buildSkinStorageMock,
-  buildSkin,
+  buildMock as buildSkinMock, buildSkin
 } from "../../skin/__tests__/skin-factory";
 import add from "../add";
 
-const buildMock = ({ skinMock, skinStorageMock }: any = {}) => {
+const buildMock = ({ skinMock }: any = {}) => {
   return {
     Database: buildSkinMock(skinMock),
-    SkinStorage: buildSkinStorageMock(skinStorageMock),
-    Socket: {
-      emit: jest.fn()
-    }
   };
 };
 
@@ -43,7 +37,7 @@ describe("add()", () => {
       packageName: "Package",
     });
 
-    const { Database, SkinStorage, Socket } = buildMock({
+    const { Database } = buildMock({
       skinStorageMock: {
         add: jest
           .fn()
@@ -53,30 +47,12 @@ describe("add()", () => {
       },
     });
 
-    await add(Database, SkinStorage, Socket, input);
+    await add(Database, input);
 
     expect(Database.findBy).toBeCalledWith(
       "name",
       input.packageName.toLowerCase()
     );
-
-    expect(SkinStorage.add).toHaveBeenNthCalledWith(1, {
-      location: "package/avatar.png",
-      base64: "base64",
-      contentType: "image/png",
-    });
-
-    expect(SkinStorage.add).toHaveBeenNthCalledWith(2, {
-      location: "package/scenario.png",
-      base64: "base64",
-      contentType: "image/png",
-    });
-
-    expect(SkinStorage.add).toHaveBeenNthCalledWith(3, {
-      location: "package/voice.mp3",
-      base64: "base64",
-      contentType: "audio/mp3",
-    });
 
     expect(Database.create).toBeCalledWith({
       name: input.packageName.toLowerCase(),
@@ -104,7 +80,7 @@ describe("add()", () => {
     it("and fail", async () => {
       const input = buildInput();
 
-      const { Database, SkinStorage, Socket } = buildMock({
+      const { Database } = buildMock({
         skinMock: {
           findBy: jest.fn().mockResolvedValue(
             buildSkin({
@@ -114,7 +90,7 @@ describe("add()", () => {
         },
       });
 
-      await expect(add(Database, SkinStorage, Socket, input)).rejects.toThrowError(
+      await expect(add(Database, input)).rejects.toThrowError(
         "There is already a package with this name"
       );
     });
@@ -131,9 +107,9 @@ describe("add()", () => {
         },
       });
 
-      const { Database, SkinStorage, Socket } = buildMock();
+      const { Database } = buildMock();
 
-      await expect(add(Database, SkinStorage, Socket, input)).rejects.toThrowError(
+      await expect(add(Database, input)).rejects.toThrowError(
         "Extension is not allowed"
       );
     });

--- a/packages/domains/src/skin/__tests__/add.test.ts
+++ b/packages/domains/src/skin/__tests__/add.test.ts
@@ -1,7 +1,9 @@
 import {
-  buildMock as buildSkinMock, buildSkin
+  buildMock as buildSkinMock,
+  buildSkin,
 } from "../../skin/__tests__/skin-factory";
 import add from "../add";
+import { SkinStatus } from "../ports/skin";
 
 const buildMock = ({ skinMock }: any = {}) => {
   return {
@@ -11,22 +13,6 @@ const buildMock = ({ skinMock }: any = {}) => {
 
 const buildInput = (data?: any) => ({
   packageName: "package",
-  images: {
-    avatar: {
-      filename: "avatar.png",
-      base64: "base64",
-    },
-    scenario: {
-      filename: "scenario.png",
-      base64: "base64",
-    },
-  },
-  sounds: {
-    voice: {
-      filename: "voice.mp3",
-      base64: "base64",
-    },
-  },
   cost: 10,
   ...data,
 });
@@ -37,15 +23,7 @@ describe("add()", () => {
       packageName: "Package",
     });
 
-    const { Database } = buildMock({
-      skinStorageMock: {
-        add: jest
-          .fn()
-          .mockResolvedValueOnce("package/avatar.png")
-          .mockResolvedValueOnce("package/scenario.png")
-          .mockResolvedValueOnce("package/voice.mp3"),
-      },
-    });
+    const { Database } = buildMock();
 
     await add(Database, input);
 
@@ -57,22 +35,7 @@ describe("add()", () => {
     expect(Database.create).toBeCalledWith({
       name: input.packageName.toLowerCase(),
       cost: input.cost,
-      images: {
-        avatar: {
-          location: "package/avatar.png",
-          name: "avatar.png",
-        },
-        scenario: {
-          location: "package/scenario.png",
-          name: "scenario.png",
-        },
-      },
-      sounds: {
-        voice: {
-          location: "package/voice.mp3",
-          name: "voice.mp3",
-        },
-      },
+      status: SkinStatus.PENDING,
     });
   });
 
@@ -92,25 +55,6 @@ describe("add()", () => {
 
       await expect(add(Database, input)).rejects.toThrowError(
         "There is already a package with this name"
-      );
-    });
-  });
-
-  describe("provides forbidden file extension", () => {
-    it("and fail", async () => {
-      const input = buildInput({
-        images: {
-          avatar: {
-            filename: "invalid.exe",
-            base64: "base64",
-          },
-        },
-      });
-
-      const { Database } = buildMock();
-
-      await expect(add(Database, input)).rejects.toThrowError(
-        "Extension is not allowed"
       );
     });
   });

--- a/packages/domains/src/skin/__tests__/get.test.ts
+++ b/packages/domains/src/skin/__tests__/get.test.ts
@@ -32,12 +32,12 @@ describe("get()", () => {
     expect(Database.findById).toBeCalledWith("id");
 
     expect(SkinStorage.get).toHaveBeenNthCalledWith(1, {
-      location: "location",
+      location: "location-scenario",
       contentType: "image/png",
     });
 
     expect(SkinStorage.get).toHaveBeenNthCalledWith(2, {
-      location: "location",
+      location: "location-avatar",
       contentType: "image/png",
     });
   });

--- a/packages/domains/src/skin/__tests__/list.test.ts
+++ b/packages/domains/src/skin/__tests__/list.test.ts
@@ -27,12 +27,12 @@ describe("list()", () => {
     expect(Database.list).toBeCalled();
 
     expect(SkinStorage.get).toHaveBeenNthCalledWith(1, {
-      location: "location",
+      location: "location-scenario",
       contentType: "image/png",
     });
 
     expect(SkinStorage.get).toHaveBeenNthCalledWith(2, {
-      location: "location",
+      location: "location-avatar",
       contentType: "image/png",
     });
   });

--- a/packages/domains/src/skin/__tests__/skin-factory.ts
+++ b/packages/domains/src/skin/__tests__/skin-factory.ts
@@ -23,6 +23,7 @@ export const buildSkinStorageMock = (skinStorageMock?: any) => {
   return {
     add: jest.fn(),
     get: jest.fn(),
+    remove: jest.fn(),
     ...skinStorageMock,
   };
 };
@@ -36,17 +37,17 @@ export const buildSkin = (data?: any): Skin => {
     images: {
       scenario: {
         name: "name.png",
-        location: "location"
+        location: "location-scenario"
       },
       avatar: {
         name: "name.png",
-        location: "location"
+        location: "location-avatar"
       }
     },
     sounds: {
       voice: {
         name: "voice.mp3",
-        location: "location"
+        location: "location-voice"
       }
     },
     ...data,

--- a/packages/domains/src/skin/__tests__/skin-factory.ts
+++ b/packages/domains/src/skin/__tests__/skin-factory.ts
@@ -1,4 +1,4 @@
-import { Skin } from "../ports/skin";
+import { Skin, SkinStatus } from "../ports/skin";
 
 export const buildMock = (skinFactory?: any) => {
   const mock = {
@@ -32,6 +32,7 @@ export const buildSkin = (data?: any): Skin => {
     id: "id",
     name: "name",
     cost: 10,
+    status: SkinStatus.ACTIVE,
     images: {
       scenario: {
         name: "name.png",

--- a/packages/domains/src/skin/__tests__/update.test.ts
+++ b/packages/domains/src/skin/__tests__/update.test.ts
@@ -1,0 +1,102 @@
+import {
+  buildMock as buildSkinMock,
+  buildSkin,
+  buildSkinStorageMock,
+} from "../../skin/__tests__/skin-factory";
+import update from "../update";
+
+const buildMock = ({ skinMock, skinStorageMock }: any = {}) => {
+  return {
+    Database: buildSkinMock(skinMock),
+    SkinStorage: buildSkinStorageMock(skinStorageMock),
+    Socket: {
+      emit: jest.fn(),
+    },
+  };
+};
+
+describe("update()", () => {
+  const skin = buildSkin();
+  const input = {
+    id: skin.id,
+    name: "new-name",
+  };
+
+  it("calls database with new name", async () => {
+    const { Database, SkinStorage, Socket } = buildMock({
+      skinMock: {
+        findById: jest.fn().mockResolvedValue(skin),
+      },
+    });
+
+    await update(Database, SkinStorage, Socket, input);
+
+    expect(Database.update).toBeCalledWith({
+      ...skin,
+      name: input.name,
+    });
+
+    expect(Socket.emit).toBeCalledWith({
+      channel: "server:skin:update",
+      message: { id: skin.id },
+    });
+  });
+
+  it("deletes old files and create new ones", async () => {
+    const { Database, SkinStorage, Socket } = buildMock({
+      skinMock: {
+        findById: jest.fn().mockResolvedValue(skin),
+      },
+      skinStorageMock: {
+        add: jest.fn().mockResolvedValue("location-scenario-2"),
+      },
+    });
+
+    await update(Database, SkinStorage, Socket, {
+      ...input,
+      images: {
+        scenario: {
+          base64: "new-base64",
+          filename: skin.images?.scenario.name ?? "",
+        },
+      },
+    });
+
+    expect(SkinStorage.add).toHaveBeenNthCalledWith(1, {
+      base64: "new-base64",
+      contentType: "image/png",
+      location: "new-name/name.png",
+    });
+
+    expect(SkinStorage.remove).toHaveBeenNthCalledWith(1, {
+      location: "location-scenario",
+    });
+  });
+
+  describe("provides inexistent skin", () => {
+    it("throws an error", async () => {
+      const { Database, SkinStorage, Socket } = buildMock();
+
+      await expect(
+        update(Database, SkinStorage, Socket, input)
+      ).rejects.toThrowError("Skin not found");
+    });
+  });
+
+  describe("provides new name for default skin", () => {
+    it("throws an error", async () => {
+      const { Database, SkinStorage, Socket } = buildMock({
+        skinMock: {
+          findById: jest.fn().mockResolvedValue({
+            ...skin,
+            name: "default"
+          })
+        }
+      });
+
+      await expect(
+        update(Database, SkinStorage, Socket, input)
+      ).rejects.toThrowError("Default skin name is not updatable");
+    });
+  });
+});

--- a/packages/domains/src/skin/add.ts
+++ b/packages/domains/src/skin/add.ts
@@ -1,29 +1,14 @@
-import { FileStorage } from "@naval-combat-server/ports";
 import { curry } from "ramda";
 
-import { Socket } from "../@types/socket";
-
-import DatabasePort, {
-  ImageFiles, SkinImageSection,
-  SkinSoundSection, SoundFiles
-} from "./ports/skin";
-import { IncomingFile, saveFiles } from "./utils/save-files";
+import DatabasePort, { SkinStatus } from "./ports/skin";
 
 type Input = {
   packageName: string;
-  images: {
-    [key in SkinImageSection]: IncomingFile;
-  };
-  sounds: {
-    [key in SkinSoundSection]: IncomingFile;
-  };
   cost: number;
 };
 
 const add = async (
   Database: typeof DatabasePort,
-  SkinStorage: FileStorage,
-  Socket: Socket,
   input: Input
 ) => {
   const loweredCasePackageName = input.packageName.toLowerCase();
@@ -34,37 +19,13 @@ const add = async (
     throw new Error("There is already a package with this name");
   }
 
-  const images = await saveFiles<ImageFiles>(
-    SkinStorage,
-    input.images,
-    loweredCasePackageName,
-    {
-      type: "image",
-    }
-  );
-
-  const sounds = await saveFiles<SoundFiles>(
-    SkinStorage,
-    input.sounds,
-    loweredCasePackageName,
-    {
-      type: "audio",
-    }
-  );
-
   const newSkin = await Database.create({
     name: loweredCasePackageName,
-    images,
-    sounds,
     cost: input.cost,
+    status: SkinStatus.PENDING
   });
 
-  await Socket.emit({
-    channel: "server:skin:add",
-    message: {
-      id: newSkin?.id,
-    },
-  });
+  return newSkin;
 };
 
 export default curry(add);

--- a/packages/domains/src/skin/get-default.ts
+++ b/packages/domains/src/skin/get-default.ts
@@ -1,6 +1,6 @@
 import { curry } from "ramda";
 
-import DatabasePort from "./ports/skin";
+import DatabasePort, { SkinStatus } from "./ports/skin";
 
 const getDefault = async (
   Database: typeof DatabasePort,
@@ -8,7 +8,7 @@ const getDefault = async (
 ) => {
   const skin = await Database.findBy("name", "default");
 
-  if(!skin) {
+  if(!skin || skin.status !== SkinStatus.ACTIVE) {
     throw new Error("Default skin is not available");
   }
 

--- a/packages/domains/src/skin/get.ts
+++ b/packages/domains/src/skin/get.ts
@@ -15,6 +15,10 @@ const get = async (
     throw new Error("Skin not found");
   }
 
+  if(!skin.images || !skin.sounds) {
+    return skin;
+  }
+
   const images = await authenticateFiles<ImageFiles>(SkinStorage, skin.images);
 
   const sounds = await authenticateFiles<SoundFiles>(SkinStorage, skin.sounds);

--- a/packages/domains/src/skin/index.ts
+++ b/packages/domains/src/skin/index.ts
@@ -13,7 +13,7 @@ import _getDefault from "./get-default";
 const SkinFileStorage = new FileStorage(process.env.SKIN_BUCKET!);
 
 export default {
-  add: _add(SkinDatabase, SkinFileStorage),
+  add: _add(SkinDatabase),
   list: _list(SkinDatabase, SkinFileStorage),
   get: _get(SkinDatabase, SkinFileStorage),
   getDefault: _getDefault(SkinDatabase),

--- a/packages/domains/src/user/__tests__/add-balance.test.ts
+++ b/packages/domains/src/user/__tests__/add-balance.test.ts
@@ -1,0 +1,34 @@
+import addBalance from "../add-balance";
+
+import {
+  buildMock as buildUserMock,
+  buildUser
+} from "./user-factory";
+
+const buildMock = ({ userMock }: any = {}) => ({
+  Database: buildUserMock(userMock),
+  Socket: {
+    emit: jest.fn()
+  }
+});
+
+describe("addBalance()", () => {
+  it("provides a value and call database updating it", async () => {
+    const user = buildUser();
+    const { Database, Socket } = buildMock();
+
+    await addBalance(Database, Socket, { user, value: 10 });
+
+    expect(Database.update).toBeCalledWith({
+      id: user.id,
+      balance: user.balance + 10
+    });
+
+    expect(Socket.emit).toBeCalledWith({
+      channel: "server:user:update",
+      message: {
+        id: user.id
+      }
+    });
+  });
+});

--- a/packages/domains/src/user/__tests__/list.test.ts
+++ b/packages/domains/src/user/__tests__/list.test.ts
@@ -1,0 +1,21 @@
+import list from "../list";
+
+import { buildMock as buildUserMock } from "./user-factory";
+
+const buildMock = ({ userMock }: any = {}) => ({
+  Database: buildUserMock(userMock),
+});
+
+describe("list()", () => {
+  it("calls database list", async () => {
+    const { Database } = buildMock({
+      userMock: {
+        list: jest.fn().mockResolvedValue([])
+      }
+    });
+
+    await list(Database, {});
+
+    expect(Database.list).toBeCalled();
+  });
+});

--- a/packages/domains/src/user/__tests__/select-skin.test.ts
+++ b/packages/domains/src/user/__tests__/select-skin.test.ts
@@ -1,0 +1,80 @@
+import selectSkin from "../select-skin";
+
+import { buildMock as buildSkinMock } from "../../skin/__tests__/skin-factory";
+
+import { buildMock as buildUserMock, buildUser } from "./user-factory";
+
+const buildMock = ({ userMock, skinMock }: any = {}) => ({
+  Database: buildUserMock(userMock),
+  Skin: buildSkinMock(skinMock),
+});
+
+describe("selectSkin()", () => {
+  const user = buildUser();
+  const input = { userId: user.id, skinId: user.skin.current };
+
+  it("provides a skinId and updates on database", async () => {
+    const { Database, Skin } = buildMock({
+      userMock: {
+        findById: jest.fn().mockResolvedValue(user),
+      },
+      skinMock: {
+        get: jest.fn().mockResolvedValue({ id: "skin" }),
+      },
+    });
+
+    await selectSkin(Database, Skin, input);
+
+    expect(Database.update).toBeCalledWith({
+      id: user.id,
+      skin: {
+        ...user.skin,
+        current: input.skinId,
+      },
+    });
+  });
+
+  describe("provide a user that not exists", () => {
+    it("throws an error", async () => {
+      const { Database, Skin } = buildMock();
+
+      await expect(selectSkin(Database, Skin, input)).rejects.toThrowError(
+        "User not found"
+      );
+    });
+  });
+
+  describe("provides a skin that not exists", () => {
+    it("throws an error", async () => {
+      const { Database, Skin } = buildMock({
+        userMock: {
+          findById: jest.fn().mockResolvedValue(user),
+        },
+      });
+
+      await expect(selectSkin(Database, Skin, input)).rejects.toThrowError(
+        "Skin not found"
+      );
+    });
+  });
+
+  describe("provides a skin that user doesn't have", () => {
+    it("throws an error", async () => {
+      const { Database, Skin } = buildMock({
+        userMock: {
+          findById: jest.fn().mockResolvedValue(user),
+        },
+        skinMock: {
+          get: jest.fn().mockResolvedValue({ id: "unknown-skin" }),
+        },
+      });
+
+      await expect(selectSkin(Database, Skin, {
+        userId: user.id,
+        skinId: "unknown-skin"
+      })).rejects.toThrowError(
+        "Skin is not available for user"
+      );
+    });
+  });
+});

--- a/packages/domains/src/user/__tests__/sign-out.test.ts
+++ b/packages/domains/src/user/__tests__/sign-out.test.ts
@@ -1,0 +1,20 @@
+import { buildMock as buildAccessTokenMock } from "../../access-token/__tests__/access-token-factory";
+import signOut from "../sign-out";
+
+const buildMock = ({ accessTokenMock }: any = {}) => ({
+  AccessToken: buildAccessTokenMock(accessTokenMock),
+});
+
+describe("signOut()", () => {
+  it("calls revoke", async () => {
+    const { AccessToken } = buildMock({
+      userMock: {
+        list: jest.fn().mockResolvedValue([])
+      }
+    });
+
+    await signOut(AccessToken, "user-id");
+
+    expect(AccessToken.revoke).toBeCalledWith("user-id");
+  });
+});

--- a/packages/domains/src/user/__tests__/update-roles.test.ts
+++ b/packages/domains/src/user/__tests__/update-roles.test.ts
@@ -1,0 +1,106 @@
+import { Roles } from "../../access-token/@types/auth-token";
+import updateRoles from "../update-roles";
+
+import { buildMock as buildUserMock, buildUser } from "./user-factory";
+
+const buildMock = ({ userMock }: any = {}) => ({
+  Database: buildUserMock(userMock),
+  Socket: {
+    emit: jest.fn(),
+  },
+});
+
+describe("updateRoles()", () => {
+  const user = buildUser({
+    id: "user-id",
+  });
+  const agent = buildUser({
+    id: "agent-id",
+  });
+
+  const input = {
+    userId: user.id,
+    agentId: agent.id,
+    roles: ["user"] as Roles[],
+  };
+
+  it("provides roles and update user", async () => {
+    const { Database, Socket } = buildMock({
+      userMock: {
+        findById: jest
+          .fn()
+          .mockImplementation((id) =>
+            [user, agent].find(({ id: filterId }) => filterId === id)
+          ),
+      },
+    });
+
+    await updateRoles(Database, Socket, input);
+
+    expect(Database.update).toBeCalledWith({
+      id: user.id,
+      roles: input.roles,
+    });
+    expect(Socket.emit).toBeCalledWith({
+      channel: "server:user:update",
+      message: { id: user.id },
+    });
+  });
+
+  describe("database don't find an agent", () => {
+    it("throws an error", async () => {
+      const { Database, Socket } = buildMock({
+        userMock: {
+          findById: jest
+            .fn()
+            .mockImplementation((id) =>
+              [user].find(({ id: filterId }) => filterId === id)
+            ),
+        },
+      });
+
+      await expect(updateRoles(Database, Socket, input)).rejects.toThrowError(
+        "Agent not found"
+      );
+    });
+  });
+
+  describe("database don't find an user", () => {
+    it("throws an error", async () => {
+      const { Database, Socket } = buildMock({
+        userMock: {
+          findById: jest
+            .fn()
+            .mockImplementation((id) =>
+              [agent].find(({ id: filterId }) => filterId === id)
+            ),
+        },
+      });
+
+      await expect(updateRoles(Database, Socket, input)).rejects.toThrowError(
+        "User not found"
+      );
+    });
+  });
+
+  describe("agent doesn't have provided role", () => {
+    it("throws an error", async () => {
+      const { Database, Socket } = buildMock({
+        userMock: {
+          findById: jest
+            .fn()
+            .mockImplementation((id) =>
+              [agent].find(({ id: filterId }) => filterId === id)
+            ),
+        },
+      });
+
+      await expect(updateRoles(Database, Socket, {
+        ...input,
+        roles: ["admin", "maintainer"]
+      })).rejects.toThrowError(
+        "User can't provide access"
+      );
+    });
+  });
+});

--- a/packages/domains/src/user/__tests__/user-factory.ts
+++ b/packages/domains/src/user/__tests__/user-factory.ts
@@ -26,6 +26,7 @@ export const buildUser = (data?: any): User => {
     },
     password: "password",
     username: "username",
+    roles: ["user"],
     balance: 100,
     ...data,
   };

--- a/packages/domains/src/user/create.ts
+++ b/packages/domains/src/user/create.ts
@@ -46,12 +46,15 @@ const create = async (
 
   const defaultSkin = await Skin.getDefault({});
 
-  if (!defaultSkin) {
+  if (!defaultSkin || (!defaultSkin.images || !defaultSkin.sounds)) {
     throw new Error("Default skin is not registered");
   }
 
+  const users = await Database.list();
+
   const user = await Database.create({
     ...input,
+    roles: users.length ? ["user"] : ["user", "maintainer", "admin"],
     skin: {
       current: defaultSkin.id,
       available: [defaultSkin.id],

--- a/packages/domains/src/user/list.ts
+++ b/packages/domains/src/user/list.ts
@@ -9,7 +9,7 @@ type Input = {
 const list = async (
   Database: typeof DatabasePort,
   _input?: Input
-): Promise<Omit<User, "password">> => {
+): Promise<Omit<User, "password">[]> => {
 
   const users = await Database.list();
 

--- a/packages/domains/src/user/ports/database.ts
+++ b/packages/domains/src/user/ports/database.ts
@@ -82,7 +82,7 @@ const create = async (user: UserInput) => {
       current: user.skin.current,
       available: user.skin.available,
     },
-    roles: ["user"],
+    roles: user.roles,
   };
 
   const createdUser = await entity.create(newUser);

--- a/packages/ports/src/database/index.ts
+++ b/packages/ports/src/database/index.ts
@@ -19,6 +19,10 @@ export default class Database {
 
     const schema = new Schema(_schema);
 
+    schema.set('toJSON', {
+      virtuals: true
+    });
+
     return mongoose.model(_model, schema);
   }
 

--- a/services/api/src/config/resolvers/index.ts
+++ b/services/api/src/config/resolvers/index.ts
@@ -31,6 +31,7 @@ import signIn from "./user/sign-in";
 import signOut from "./user/sign-out";
 import updateRoles from "./user/update-roles";
 import selectSkin from "./user/select-skin";
+import initialSetup from "./setup/initial-setup";
 
 export const resolvers = {
   Query: {
@@ -57,6 +58,8 @@ export const resolvers = {
     ) => getPendingFunds(FundsDomain, accessTokenData),
   },
   Mutation: {
+    initialSetup: async (_parent: any, _args: any) =>
+      initialSetup(UserDomain, SkinDomain, NavalCombatSocket, _args.input),
     createUser: async (_parent: any, _args: any) =>
       createUser(UserDomain, NavalCombatSocket, _args.input),
     signIn: async (_parent: any, _args: any) => signIn(UserDomain, _args.input),
@@ -82,7 +85,7 @@ export const resolvers = {
       _parent: any,
       _args: any,
       { accessTokenData }: ServerContext
-    ) => addSkin(SkinDomain, NavalCombatSocket, accessTokenData, _args.input),
+    ) => addSkin(SkinDomain, accessTokenData, _args.input),
     removeSkin: async (
       _parent: any,
       _args: any,

--- a/services/api/src/config/resolvers/setup/initial-setup.ts
+++ b/services/api/src/config/resolvers/setup/initial-setup.ts
@@ -1,0 +1,49 @@
+import {
+  skin as SkinDomain, user as UserDomain
+} from "@naval-combat-server/domains";
+import { SkinStatus } from "@naval-combat-server/domains/build/src/skin/ports/skin";
+
+import { NavalCombatSocket as NavalCombatSocketPort } from "../../../ports/notification";
+
+const initialSetup = async (
+  user: typeof UserDomain,
+  skin: typeof SkinDomain,
+  NavalCombatSocket: typeof NavalCombatSocketPort,
+  { user: userInput, skin: skinInput }: any
+) => {
+  const users = await user.list({});
+
+  if (users.length) {
+    throw new Error("Setup already made");
+  }
+
+  try {
+    await skin.getDefault({});
+
+    throw new Error("Default skin is already created");
+  } catch (error: any) {
+    const isDefaultSkinNotAvailable =
+      error.message === "Default skin is not available";
+
+    if (!isDefaultSkinNotAvailable) {
+      throw error;
+    }
+  }
+
+  const newSkin = await skin.add( {
+    packageName: "default",
+    cost: 0,
+  });
+
+  await skin.update(NavalCombatSocket, {
+    id: newSkin.id,
+    status: SkinStatus.ACTIVE,
+    ...skinInput,
+  });
+
+  await user.create(NavalCombatSocket, userInput);
+
+  return true;
+};
+
+export default initialSetup;

--- a/services/api/src/config/resolvers/skins/add-skin.ts
+++ b/services/api/src/config/resolvers/skins/add-skin.ts
@@ -2,7 +2,6 @@ import { skin as SkinDomain } from "@naval-combat-server/domains";
 import { AuthToken } from "@naval-combat-server/domains/build/src/access-token/@types/auth-token";
 import { AuthenticationError, ForbiddenError } from "apollo-server";
 
-import { NavalCombatSocket as NavalCombatSocketPort } from "../../../ports/notification";
 import { roleChecker } from "../../tools";
 
 export type File = {
@@ -24,16 +23,15 @@ type Input = {
 
 const addSkin = async (
   skin: typeof SkinDomain,
-  NavalCombatSocket: typeof NavalCombatSocketPort,
   accessTokenData: AuthToken | undefined,
   input: Input
 ) => {
   const skins = await skin.list({});
 
   if (!skins.length && input.packageName === "default") {
-    await skin.add(NavalCombatSocket, input);
+    const newSkin = await skin.add(input);
 
-    return true;
+    return newSkin;
   }
 
   if (!accessTokenData) {
@@ -46,9 +44,9 @@ const addSkin = async (
     throw new ForbiddenError("FORBIDDEN");
   }
 
-  await skin.add(NavalCombatSocket, input);
+  const newSkin = await skin.add(input);
 
-  return true;
+  return newSkin;
 };
 
 export default addSkin;

--- a/services/api/src/config/resolvers/skins/update-skin.ts
+++ b/services/api/src/config/resolvers/skins/update-skin.ts
@@ -1,5 +1,6 @@
 import { skin as SkinDomain } from "@naval-combat-server/domains";
 import { AuthToken } from "@naval-combat-server/domains/build/src/access-token/@types/auth-token";
+import { SkinStatus } from "@naval-combat-server/domains/build/src/skin/ports/skin";
 import { AuthenticationError, ForbiddenError } from "apollo-server";
 
 import { NavalCombatSocket as NavalCombatSocketPort } from "../../../ports/notification";
@@ -18,6 +19,7 @@ type Input = {
   sounds?: {
     voice: File;
   };
+  status?: SkinStatus
 };
 
 const updateSkin = async (

--- a/services/api/src/config/schema.ts
+++ b/services/api/src/config/schema.ts
@@ -43,14 +43,18 @@ export const typeDefs = gql`
   input AddSkinInput {
     packageName: String!
     cost: Int!
-    images: SkinImagesDefinition!
-    sounds: SkinSoundDefinition!
   }
 
   input UpdateSkinInput {
     id: ID!
     cost: Int
     name: String
+    images: SkinImagesDefinition
+    sounds: SkinSoundDefinition
+    status: SkinStatus
+  }
+
+  input InitialSetupSkinInput {
     images: SkinImagesDefinition
     sounds: SkinSoundDefinition
   }
@@ -94,6 +98,11 @@ export const typeDefs = gql`
     skinId: String!
   }
 
+  input InitialSetupInput {
+    user: CreateUserInput!
+    skin: InitialSetupSkinInput!
+  }
+
   type User {
     id: ID!
     email: String!
@@ -113,9 +122,10 @@ export const typeDefs = gql`
     id: ID!
     cost: Int!
     name: String!
-    scenario: String!
-    avatar: String!
-    voice: String!
+    scenario: String
+    avatar: String
+    voice: String
+    status: SkinStatus!
   }
 
   type UserMeta {
@@ -166,14 +176,21 @@ export const typeDefs = gql`
     CREDITED
   }
 
+  enum SkinStatus {
+    PENDING
+    ACTIVE
+    DISABLED
+  }
+
   type Mutation {
+    initialSetup(input: InitialSetupInput!): Boolean
     createUser(input: CreateUserInput!): User!
     signIn(input: SignInInput!): SignIn!
     signOut: Boolean
-    refresh(input: RefreshTokenInput!): SignIn!
+    refresh(input: RefreshTokenInput!): Tokens!
     createRoom(input: CreateRoomInput!): Room!
     joinRoom(input: JoinRoomInput!): Boolean
-    addSkin(input: AddSkinInput!): Boolean
+    addSkin(input: AddSkinInput!): Skin!
     buySkin(input: BuySkinInput!): Boolean
     removeSkin(input: RemoveSkinInput!): Boolean
     updateSkin(input: UpdateSkinInput!): Boolean

--- a/services/api/src/config/tools/role-checker.ts
+++ b/services/api/src/config/tools/role-checker.ts
@@ -1,9 +1,9 @@
 import { AuthToken } from "@naval-combat-server/domains/build/src/access-token/@types/auth-token";
 
 const roleChecker = (accessTokenData: AuthToken) => {
-  const isMaintainer = accessTokenData.roles.includes("maintainer");
+  const isMaintainer = accessTokenData?.roles?.includes("maintainer");
 
-  const isAdmin = accessTokenData.roles.includes("admin");
+  const isAdmin = accessTokenData?.roles?.includes("admin");
 
   return {
     isMaintainer, isAdmin

--- a/services/notification/src/handlers/skin/index.ts
+++ b/services/notification/src/handlers/skin/index.ts
@@ -3,29 +3,11 @@ import { Socket } from "socket.io";
 import { IOHandler } from "../../config/tools";
 
 interface SkinSocketEvents {
-  "server:skin:add": (message: any) => void;
   "server:skin:update": (message: any) => void;
   "server:skin:remove": (message: any) => void;
 }
 
 const register = (socket: Socket<SkinSocketEvents>): void => {
-  socket.on("server:skin:add", async (message: any) => {
-    await IOHandler.handleOrigin<{ id: string; userId: string }>(
-      "server:skin:add",
-      message,
-      socket
-    );
-
-    IOHandler.toAll({
-      channel: "client:skin:add",
-      message: {
-        date: new Date().getTime()
-      }
-    });
-
-    return;
-  });
-
   socket.on("server:skin:update", async (message: any) => {
     await IOHandler.handleOrigin<{ id: string; userId: string }>(
       "server:skin:update",

--- a/services/notification/src/handlers/user/index.ts
+++ b/services/notification/src/handlers/user/index.ts
@@ -10,11 +10,20 @@ interface UserSocketEvents {
 
 const register = (socket: Socket<UserSocketEvents>): void => {
   socket.on("client:signIn", async () => {
-    await IOHandler.handleOrigin<{ id: string; userId: string }>(
-      "client:signIn",
-      Buffer.from("{}"),
-      socket
-    );
+    try {
+      await IOHandler.handleOrigin<{ id: string; userId: string }>(
+        "client:signIn",
+        Buffer.from("{}"),
+        socket
+      );
+    } catch {
+      IOHandler.toUser(socket.id, {
+        channel: "client:request:signOut",
+        message: {
+          date: new Date().getTime(),
+        }
+      });
+    }
 
     return;
   });


### PR DESCRIPTION
- fix: update skin methods to setup projecto on init
- fix: add optional chaining to avoid error
- fix: remove event from skin add and handle invalid token
- feat: make first user full admin
- feat: enable virtuals for mongo
- feat: add initial setup mutation
- feat: remove extra skin code
- fix: remove socket and skin storage form add test
- fix: update tests of functions
- test: add missing user tests
- test: add missing tests for skin
- test: add funds tests
